### PR TITLE
Add flag disable_openapi_validation

### DIFF
--- a/helm/resource_release.go
+++ b/helm/resource_release.go
@@ -245,6 +245,12 @@ func resourceRelease() *schema.Resource {
 				Default:     true,
 				Description: "If set, render subchart notes along with the parent",
 			},
+			"disable_openapi_validation": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "If set, the installation process will not validate rendered templates against the Kubernetes OpenAPI Schema",
+			},
 			"wait": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -429,6 +435,7 @@ func resourceReleaseCreate(d *schema.ResourceData, meta interface{}) error {
 	client.Atomic = d.Get("atomic").(bool)
 	client.SkipCRDs = d.Get("skip_crds").(bool)
 	client.SubNotes = d.Get("render_subchart_notes").(bool)
+	client.DisableOpenAPIValidation = d.Get("disable_openapi_validation").(bool)
 	client.Replace = d.Get("replace").(bool)
 	client.Description = d.Get("description").(string)
 

--- a/website/docs/r/release.html.markdown
+++ b/website/docs/r/release.html.markdown
@@ -76,6 +76,7 @@ The following arguments are supported:
 * `atomic` - (Optional) If set, installation process purges chart on fail. The wait flag will be set automatically if atomic is used. Defaults to `false`.
 * `skip_crds` - (Optional) If set, no CRDs will be installed. By default, CRDs are installed if not already present. Defaults to `false`.
 * `render_subchart_notes` - (Optional) If set, render subchart notes along with the parent. Defaults to `true`.
+* `disable_openapi_validation` - (Optional) If set, the installation process will not validate rendered templates against the Kubernetes OpenAPI Schema. Defaults to `false`.
 * `wait` - (Optional) Will wait until all resources are in a ready state before marking the release as successful. It will wait for as long as `timeout`. Defaults to `true`.
 * `values` - (Optional) List of values in raw yaml to pass to helm. Values will be merged, in order, as Helm does with multiple `-f` options.
 * `set` - (Optional) Value block with custom values to be merged with the values yaml.


### PR DESCRIPTION
In this PR I'm adding a new flag `disable_openapi_validation` which uses --disable-openapi-validation offered by the command line tool.